### PR TITLE
Mark unsused private variables as @Deprecated

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/CrossEntry.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/CrossEntry.java
@@ -12,8 +12,10 @@ public abstract class CrossEntry
 
     public abstract void insert();
 
+    @Deprecated
     private TransactionOwner<Transaction> primaryTransactionOwner;
 
+    @Deprecated
     private TransactionOwner<Transaction> secondaryTransactionOwner;
 
     public abstract void setPrimaryTransactionOwner(TransactionOwner<Transaction> transactionOwner);


### PR DESCRIPTION
Due to the BEAN API specification the private variables are mandatory to defined the Getter/Setter methods but are unused and it is discourage to work with them.